### PR TITLE
Fix Q2: disable automount in pod spec and update expected answer to NO (ch_automounting-sa/step2)

### DIFF
--- a/ch_automounting-sa/step2/step.md
+++ b/ch_automounting-sa/step2/step.md
@@ -61,7 +61,7 @@ YES,NO,NO
         namespace: poc-sa-mount
       spec:
         serviceAccountName: sa-secure
-        automountServiceAccountToken: true
+        automountServiceAccountToken: false
         containers:
         - name: busybox
           image: busybox
@@ -72,7 +72,7 @@ YES,NO,NO
       kubectl apply -f q2-secure-sa.yaml
       kubectl exec -n poc-sa-mount q2-secure-sa -- ls /var/run/secrets/kubernetes.io/serviceaccount/
       ```
-      It returns the files! `token`, `ca.crt`, `namespace`, that means the token is not mounted, then the answer is `YES`
+      That means the token is not mounted, then the answer is `NO`
 
   5. **Q3: Create a busybox pod in `default` namespace with automount disabled:**
 
@@ -99,7 +99,7 @@ YES,NO,NO
   6. **Write answers to `/tmp/ch-answer.txt`:**
 
       ```bash
-      echo "NO,YES,NO" > /tmp/ch-answer.txt
+      echo "NO,NO,NO" > /tmp/ch-answer.txt
       ```
   
   7. **Important Notes**:

--- a/ch_automounting-sa/step2/verify.sh
+++ b/ch_automounting-sa/step2/verify.sh
@@ -3,7 +3,7 @@
 pod_exists=$(kubectl get pod -A | grep -w -E 'q1-secure-sa|q2-secure-sa|q3-secure-sa')
 answer=$(cat /tmp/ch-answer.txt)
 
-if [[ -n "$pod_exists" && "$answer" == "NO,YES,NO" ]]; then
+if [[ -n "$pod_exists" && "$answer" == "NO,NO,NO" ]]; then
   exit 0
 else
   exit 1


### PR DESCRIPTION
The Q2 task clearly asks to create a pod **with automount disabled** in the pod spec,
but the current solution and expected output use `automountServiceAccountToken: true`
and answer **YES**, which contradicts the requirement.

This PR:
- Sets `automountServiceAccountToken: false` in step2/step.md
- Updates the expected answer in `ch-answer.txt` to **NO**
- Keeps verify.sh consistent with expected "NO" answers for Q1–Q3

Result:
- Pod correctly runs **without** a mounted ServiceAccount token.
- Verification now matches the task (NO).

Closes #2